### PR TITLE
protect listing management with http basic auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+.env

--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,7 @@ gem "bootsnap", require: false
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
+  gem 'dotenv-rails'
   gem "debug", platforms: %i[ mri windows ]
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,6 +103,10 @@ GEM
     debug (1.10.0)
       irb (~> 1.10)
       reline (>= 0.3.8)
+    dotenv (3.1.8)
+    dotenv-rails (3.1.8)
+      dotenv (= 3.1.8)
+      railties (>= 6.1)
     drb (2.2.1)
     erubi (1.13.1)
     ffi (1.17.2-x86_64-linux-gnu)
@@ -259,6 +263,7 @@ DEPENDENCIES
   bootsnap
   capybara
   debug
+  dotenv-rails
   image_processing (~> 1.2)
   importmap-rails
   jbuilder

--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -1,4 +1,5 @@
 class ListingsController < ApplicationController
+  before_action :authenticate_admin!, only: [:new, :create, :edit, :update, :destroy]
   before_action :set_listing, only: %i[ show edit update destroy ]
 
   # GET /listings or /listings.json
@@ -57,7 +58,14 @@ class ListingsController < ApplicationController
     end
   end
 
-  private
+    private
+def authenticate_admin!
+  authenticate_or_request_with_http_basic("Admin Area") do |user, pass|
+    user == ENV["ADMIN_USER"] && pass == ENV["ADMIN_PASS"]
+  end
+end
+
+
     # Use callbacks to share common setup or constraints between actions.
     def set_listing
       @listing = Listing.find(params[:id])
@@ -68,3 +76,4 @@ class ListingsController < ApplicationController
       params.require(:listing).permit(:year, :make, :model, :odometer, :price, :photo)
     end
 end
+	


### PR DESCRIPTION
This adds HTTP Basic Auth to the listing CRUD actions and persists creds via dotenv‑rails